### PR TITLE
libtasn1 4.20.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,12 +3,28 @@
 # Get an updated config.sub and config.guess
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 
-./configure --prefix=$PREFIX \
-    --disable-static    \
-    --enable-shared     \
-    --disable-gtk-doc
+# ./configure --prefix=$PREFIX \
+#     --disable-static    \
+#     --enable-shared     \
+#     --disable-doc       \
+#     --disable-silent-rules
 
-make -j $CPU_COUNT
+./configure \
+      --prefix="${PREFIX}" \
+      --host="${HOST}" \
+      --build="${BUILD}" \
+      --disable-static \
+      --enable-shared \
+      --disable-doc \
+      --disable-gtk-doc \
+      --disable-gtk-doc-html \
+      --disable-gtk-doc-pdf \
+      --disable-valgrind-tests \
+      --disable-dependency-tracking \
+      --disable-silent-rules \
+      --enable-year2038
+
+make -j ${CPU_COUNT}
 
 make install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "libtasn1" %}
-{% set version = "4.19.0" %}
+{% set version = "4.20.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1613f0ac1cf484d6ec0ce3b8c06d56263cc7242f1c23b30d82d23de345a63f7a
+  url: https://ftpmirror.gnu.org/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c
 
 build:
   number: 0
@@ -22,8 +22,6 @@ requirements:
     - {{ compiler('c') }}
     - make    # [unix]
     - libtool  # [unix]
-  host:
-  run:
 
 test:
   requires:
@@ -31,12 +29,17 @@ test:
     - conda-build  # [osx]
 
   commands:
+    - ls -l "${PREFIX}/bin" || true             # [unix]
+    - command -v asn1Parser                     # [unix]
+    - asn1Parser --version                      # [unix]
+    - command -v asn1Coding && asn1Coding --help || true  # [unix]
     - test -f $PREFIX/lib/libtasn1${SHLIB_EXT}  # [unix]
+    - test -f ${PREFIX}/include/libtasn1.h      # [unix]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
-  home: https://www.gnu.org/software/libtasn1/
+  home: https://www.gnu.org/software/libtasn1
   license_family: LGPL
   license: LGPL-2.1-or-later
   license_file: COPYING
@@ -46,7 +49,7 @@ about:
     (ASN.1, as specified by the X.680 ITU-T recommendation) parsing and structures management,
     and Distinguished Encoding Rules (DER, as per X.690) encoding and decoding functions.
   doc_url: https://www.gnu.org/software/libtasn1/manual/libtasn1.html
-  dev_url: https://gitlab.com/gnutls/libtasn1/
+  dev_url: https://gitlab.com/gnutls/libtasn1
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make    # [unix]
     - libtool  # [unix]


### PR DESCRIPTION
libtasn1 4.20.0

**Destination channel:** Defaults

### Links

- [PKG-9834]
Project Feedstock URL: https://github.com/AnacondaRecipes/libtasn1-feedstock
Project Home URL: https://www.gnu.org/software/libtasn1/
Project Dev URL: https://gitlab.com/gnutls/libtasn1/

### Explanation of changes:

- new version number

[PKG-9834]: https://anaconda.atlassian.net/browse/PKG-9834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ